### PR TITLE
Add Demo User Seed Endpoint

### DIFF
--- a/WebAppAPI/Controllers/UsersController.cs
+++ b/WebAppAPI/Controllers/UsersController.cs
@@ -48,6 +48,38 @@ namespace WebAppAPI.Controllers
 			}
 		}
 
+		// --- BEGIN: TEMPORARY DEMO USER SEED ENDPOINT ---
+		[AllowAnonymous]
+		[HttpPost]
+		[Route("SeedDemoUser")]
+		public async Task<IActionResult> SeedDemoUser()
+		{
+			var userName = "demo";
+			var userPassword = "demo";
+
+			// Check if user already exists
+			var allUsers = await _usersFunction.GetAllUsers();
+			if (allUsers.Any(u => u.UserName == userName))
+				return Ok("Demo user already exists!");
+
+			// Get the DbContext
+			var dbContext = (DatabaseAccess.Data.Context.MainAppDbContext)HttpContext.RequestServices.GetService(typeof(DatabaseAccess.Data.Context.MainAppDbContext));
+			if (dbContext == null)
+				return StatusCode(500, "DbContext not available");
+
+			var newUser = new DatabaseAccess.Data.EntityModels.AspNetUserDAO
+			{
+				Id = Guid.NewGuid().ToString(),
+				UserName = userName,
+				UserPassword = userPassword
+			};
+			dbContext.AspNetUsers.Add(newUser);
+			await dbContext.SaveChangesAsync();
+
+			return Ok("Demo user created: demo/demo");
+		}
+		// --- END: TEMPORARY DEMO USER SEED ENDPOINT ---
+
 		[Authorize(Roles = "User, Admin")] // prefer to use enums, but requires custom attribute
 		[HttpGet]
 		[Route("GetAllUsers")]


### PR DESCRIPTION
This pull request introduces a new endpoint to seed a temporary demo user in the UsersController. The endpoint, `SeedDemoUser`, allows for the creation of a demo user with predefined credentials if one does not already exist. It checks for the existence of the demo user and, if absent, creates a new user with the username 'demo' and password 'demo'. This feature is intended for testing and demonstration purposes, providing a quick way to set up a demo environment without manual user creation.

---

> This pull request was co-created with Cosine Genie

Original Task: [Student/6j5lc9ap9661](https://cosine.sh/3bsqy1bh8osk/Student/task/6j5lc9ap9661)
Author: donclasshelp
